### PR TITLE
Respect includeChildren; make false by default.

### DIFF
--- a/src/Type/TaxQueryType.php
+++ b/src/Type/TaxQueryType.php
@@ -83,7 +83,8 @@ class TaxQueryType extends WPInputObjectType {
 					'includeChildren' => [
 						'type'        => Types::boolean(),
 						'description' => __( 'Whether or not to include children for hierarchical 
-										taxonomies. Defaults to true', 'wp-graphql' ),
+										taxonomies. Defaults to false to improve performance (note that
+										this is opposite of the default for WP_Query).', 'wp-graphql' ),
 					],
 					'operator'        => [
 						'type' => new WPEnumType([

--- a/wp-graphql-tax-query.php
+++ b/wp-graphql-tax-query.php
@@ -184,6 +184,15 @@ class TaxQuery {
 						}
 					}
 
+					// Make "include_children => false" for performance reasons unless
+					// it is specifically requested (but one really shouldn't). See
+					// https://vip.wordpress.com/documentation/term-queries-should-consider-include_children-false/
+					$value['include_children'] = false;
+					if ( isset( $value['includeChildren'] ) ) {
+						$value['include_children'] = $value['includeChildren'];
+						unset( $value['includeChildren'] );
+					}
+
 					$tax_query[] = [
 						$tax_array_key => $value,
 					];


### PR DESCRIPTION
The `includeChildren` query var was not being respected. This PR also makes it `false` by default for performance reasons. See:

https://vip.wordpress.com/documentation/term-queries-should-consider-include_children-false/