### PR TITLE
Using a taxonomy query doesn't set the request type properly in WP_Query

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # WPGraphQL Tax Query
 
-This plugin adds Tax_Query support to the WP GraphQL Plugin for postObject query args (WP_Query). 
+This plugin adds Tax_Query support to the WP GraphQL Plugin for postObject query args (WP_Query).
 
 ## Pre-req's
-Using this plugin requires having the <a href="https://github.com/wp-graphql/wp-graphql" target="_blank">WPGraphQL plugin</a> installed 
+Using this plugin requires having the <a href="https://github.com/wp-graphql/wp-graphql" target="_blank">WPGraphQL plugin</a> installed
 and activated. (version 0.0.15 or newer)
 
 ## Activating / Using
-Activate the plugin like you would any other WordPress plugin. 
+Activate the plugin like you would any other WordPress plugin.
 
-Once the plugin is active, the `taxQuery` argument will be available to any post object connectionQuery 
+Once the plugin is active, the `taxQuery` argument will be available to any post object connectionQuery
 (posts, pages, custom post types, etc).
 
 ## Example Query
-Below is an example Query using the taxQuery input on a `posts` query. (Go ahead and check things out in 
+Below is an example Query using the taxQuery input on a `posts` query. (Go ahead and check things out in
 <a target="_blank" href="https://chrome.google.com/webstore/detail/chromeiql/fkkiamalmpiidkljmicmjfbieiclmeij?hl=en">GraphiQL</a>)
 
-This will find `posts` that are in the category "graphql" OR tagged with "wordpress". 
+This will find `posts` that are in the category "graphql" OR tagged with "wordpress".
 
 ```
 query{
@@ -33,7 +33,7 @@ query{
           },
           {
             terms: ["wordpress"],
-            taxonomy: POST_TAG,
+            taxonomy: TAG,
             operator: IN,
             field: SLUG
           }
@@ -54,7 +54,7 @@ query{
 }
 ```
 
-The same query in PHP using WP_Query would look like: 
+The same query in PHP using WP_Query would look like:
 
 ```
 $args = [

--- a/wp-graphql-tax-query.php
+++ b/wp-graphql-tax-query.php
@@ -189,7 +189,7 @@ class TaxQuery {
 						unset( $value['includeChildren'] );
 					}
 
-					$tax_query[$tax_array_key] = $value;
+					$tax_query[ $tax_array_key ] = $value;
 				}
 			}
 			unset( $tax_query['taxArray'] );

--- a/wp-graphql-tax-query.php
+++ b/wp-graphql-tax-query.php
@@ -189,9 +189,7 @@ class TaxQuery {
 						unset( $value['includeChildren'] );
 					}
 
-					$tax_query[] = [
-						$tax_array_key => $value,
-					];
+					$tax_query[$tax_array_key] = $value;
 				}
 			}
 			unset( $tax_query['taxArray'] );


### PR DESCRIPTION
When using a `taxQuery` in a query, the taxonomy relevant request type properties are not set correctly on `WP_Query`. So for example when querying a category `$wp_query->is_category` returns `false` even though it should be `true`. Or when combining a tag and category related query, e.g. 

```
query THE_POSTS {
  posts(
    first: 10
    where: {
      taxQuery: {
        relation: OR,
        taxArray: [
          { taxonomy: CATEGORY, field: SLUG, terms: ["startseite", "kultur"] }
          { taxonomy: TAG, field: SLUG, terms: "bangladesch" }
        ]
      }
    }
  ) {
    pageInfo {
      hasNextPage
      endCursor
    }
    nodes {
      title
      postId
    }
  }
}
```

both `$wp_query->is_tag` and `$wp_query->is_category` should be true.

This was caused because the the taxonomy queries were nested inside an additional array in `map_input_fields`  which caused the functionality in https://github.com/WordPress/WordPress/blob/32d761ce7dc8429f07469fde36e96830edca48f1/wp-includes/class-wp-query.php#L885 not to trigger.

The query worked fine though, but plugins relating on the request type failed.