### PR TITLE
Fix term arrays for ID & TAXONOMY_ID

### DIFF
--- a/wp-graphql-tax-query.php
+++ b/wp-graphql-tax-query.php
@@ -274,7 +274,7 @@ class TaxQuery {
 						if ( ! empty( $value['field'] ) && ( 'term_id' === $value['field'] || 'term_taxonomy_id' === $value['field'] ) ) {
 							$formatted_terms = [];
 							foreach ( $value['terms'] as $term ) {
-								$formatted_terms = intval( $term );
+								$formatted_terms[] = intval( $term );
 							}
 							$value['terms'] = $formatted_terms;
 						}


### PR DESCRIPTION
When querying by field ID or TAXONOMY_ID the results were incorrect because it was only using the last element in the original array