### PR TITLE
Fix issue with array term value being overwritten

### DIFF
--- a/wp-graphql-tax-query.php
+++ b/wp-graphql-tax-query.php
@@ -274,7 +274,7 @@ class TaxQuery {
 						if ( ! empty( $value['field'] ) && ( 'term_id' === $value['field'] || 'term_taxonomy_id' === $value['field'] ) ) {
 							$formatted_terms = [];
 							foreach ( $value['terms'] as $term ) {
-								$formatted_terms = intval( $term );
+								$formatted_terms[] = intval( $term );
 							}
 							$value['terms'] = $formatted_terms;
 						}


### PR DESCRIPTION
The formatted terms needs to add brackets in order for the int value of the termID to be pushed to a new array item. Currently, the value of the formatted_term is overwritten for each term. This fixes that issue.