### PR TITLE
release: v0.2.0

### DIFF
--- a/wp-graphql-tax-query.php
+++ b/wp-graphql-tax-query.php
@@ -261,7 +261,7 @@ class TaxQuery {
 
 				// If less than 2 taxArray objects were passed through, we don't need the "relation" field
 				// to be passed to WP_Query, so we'll unset it now
-				if ( 2 < count( $tax_query['taxArray'] ) ) {
+				if ( 2 > count( $tax_query['taxArray'] ) ) {
 					unset( $tax_query['relation'] );
 				}
 

--- a/wp-graphql-tax-query.php
+++ b/wp-graphql-tax-query.php
@@ -54,6 +54,9 @@ class TaxQuery {
 		 */
 		$this->includes();
 
+		// Register Tax Query Types
+		add_action( get_graphql_register_action(), [ $this, 'register_types' ], 10, 1 );
+
 		/**
 		 * Filter the query_args for the PostObjectQueryArgsType
 		 * @since 0.0.1
@@ -131,24 +134,22 @@ class TaxQuery {
 	public function add_input_fields( $fields, $type_name, $config, $type_registry ) {
 
 		if ( isset( $config['queryClass'] ) && 'WP_Query' === $config['queryClass'] ) {
-
-			$this->register_types( $type_name, $type_registry );
 			$fields['taxQuery'] = [
-				'type' => $type_name . 'TaxQuery'
+				'type' => 'TaxQuery'
 			];
 		}
+
 		return $fields;
 	}
 
 	/**
-	 * @param              $type_name
 	 * @param TypeRegistry $type_registry
 	 *
 	 * @throws \Exception
 	 */
-	public function register_types( $type_name, TypeRegistry $type_registry ) {
+	public function register_types( TypeRegistry $type_registry ) {
 
-		$type_registry->register_enum_type( $type_name . 'TaxQueryField', [
+		$type_registry->register_enum_type( 'TaxQueryField', [
 			'description' => __( 'Which field to select taxonomy term by. Default value is "term_id"', 'wp-graphql' ),
 			'values'      => [
 				'ID'          => [
@@ -170,7 +171,7 @@ class TaxQuery {
 			],
 		] );
 
-		$type_registry->register_enum_type( $type_name . 'TaxQueryOperator', [
+		$type_registry->register_enum_type( 'TaxQueryOperator', [
 			'values' => [
 				'IN'         => [
 					'name'  => 'IN',
@@ -195,13 +196,13 @@ class TaxQuery {
 			],
 		] );
 
-		$type_registry->register_input_type( $type_name . 'TaxArray', [
+		$type_registry->register_input_type( 'TaxArray', [
 			'fields' => [
 				'taxonomy'        => [
 					'type' => 'TaxonomyEnum',
 				],
 				'field'           => [
-					'type' => $type_name . 'TaxQueryField',
+					'type' => 'TaxQueryField',
 				],
 				'terms'           => [
 					'type'        => [ 'list_of' => 'String' ],
@@ -212,12 +213,12 @@ class TaxQuery {
 					'description' => __( 'Whether or not to include children for hierarchical taxonomies. Defaults to false to improve performance (note that this is opposite of the default for WP_Query).', 'wp-graphql' ),
 				],
 				'operator'        => [
-					'type' => $type_name . 'TaxQueryOperator',
+					'type' => 'TaxQueryOperator',
 				],
 			]
 		] );
 
-		$type_registry->register_input_type( $type_name . 'TaxQuery', [
+		$type_registry->register_input_type( 'TaxQuery', [
 			'description' => __( 'Query objects based on taxonomy parameters', 'wp-graphql' ),
 			'fields'      => [
 				'relation' => [
@@ -225,7 +226,7 @@ class TaxQuery {
 				],
 				'taxArray' => [
 					'type' => [
-						'list_of' => $type_name . 'TaxArray',
+						'list_of' => 'TaxArray',
 					],
 				],
 			],

--- a/wp-graphql-tax-query.php
+++ b/wp-graphql-tax-query.php
@@ -5,7 +5,7 @@
  * Description: Tax_Query support for the WPGraphQL plugin. Requires WPGraphQL version 0.4.0 or newer.
  * Author: WPGraphQL, Jason Bahl
  * Author URI: https://www.wpgraphql.com
- * Version: 0.1.0
+ * Version: 0.2.0
  * Text Domain: wp-graphql-tax-query
  * Requires at least: 4.7.0
  * Tested up to: 4.7.1

--- a/wp-graphql-tax-query.php
+++ b/wp-graphql-tax-query.php
@@ -274,7 +274,7 @@ class TaxQuery {
 						if ( ! empty( $value['field'] ) && ( 'term_id' === $value['field'] || 'term_taxonomy_id' === $value['field'] ) ) {
 							$formatted_terms = [];
 							foreach ( $value['terms'] as $term ) {
-								$formatted_terms = intval( $term );
+								$formatted_terms[] = intval( $term );
 							}
 							$value['terms'] = $formatted_terms;
 						}


### PR DESCRIPTION
# BREAKING CHANGE

This release include a breaking change to the Schema. Some Types have changed to simplify things. 

READ MORE HERE: https://github.com/wp-graphql/wp-graphql-tax-query/pull/32#issue-1305271626

----

### Chores / Bugfixes

- ([#23](https://github.com/wp-graphql/wp-graphql-tax-query/pull/23)): fix: term arrays for ID and TAXONOMY_ID. Thanks @iamlili!
- ([#19](https://github.com/wp-graphql/wp-graphql-tax-query/pull/19)): fix: Unset relation field when count is less than 2. Thanks @daltonrooney! 
- ([#12](https://github.com/wp-graphql/wp-graphql-tax-query/pull/12)): fix: Using a taxonomy query doesn't set the request type properly in WP_Query. Thanks @mwidmann!